### PR TITLE
SX-253

### DIFF
--- a/lib/puppeteer/cache.js
+++ b/lib/puppeteer/cache.js
@@ -1,0 +1,11 @@
+const path = require('path');
+
+const appData = process.env.APPDATA || (process.platform === 'darwin'
+    ? path.join(process.env.HOME || '', 'Library/Preferences') : '/var/local');
+
+const chromiumCachePath = process.env.WEB_TESTER_CHROMIUM_CACHE
+    || process.env.npm_config_web_tester_chromium_cache
+    || process.env.npm_package_web_tester_chromium_cache
+    || path.join(appData, 'web-tester-chromium');
+
+module.exports = chromiumCachePath;

--- a/lib/puppeteer/download.js
+++ b/lib/puppeteer/download.js
@@ -1,0 +1,68 @@
+/* eslint-disable no-console */
+const BrowserFetcher = require('puppeteer-core/lib/BrowserFetcher');
+const puppeteerPkg = require('puppeteer-core/package.json');
+const fs = require('fs');
+const chromiumCachePath = require('./cache');
+
+try {
+    fs.lstatSync(chromiumCachePath);
+} catch (e) {
+    fs.mkdirSync(chromiumCachePath);
+}
+
+const downloadHost = process.env.PUPPETEER_DOWNLOAD_HOST
+    || process.env.npm_config_puppeteer_download_host
+    || process.env.npm_package_config_puppeteer_download_host;
+
+const browserFetcher = new BrowserFetcher(chromiumCachePath, { host: downloadHost });
+
+const revision = process.env.PUPPETEER_CHROMIUM_REVISION
+    || process.env.npm_config_puppeteer_chromium_revision
+    || process.env.npm_package_config_puppeteer_chromium_revision
+    || puppeteerPkg.puppeteer.chromium_revision;
+
+const revisionInfo = browserFetcher.revisionInfo(revision);
+
+// Override current environment proxy settings with npm configuration, if any.
+const NPM_HTTPS_PROXY = process.env.npm_config_https_proxy || process.env.npm_config_proxy;
+const NPM_HTTP_PROXY = process.env.npm_config_http_proxy || process.env.npm_config_proxy;
+const NPM_NO_PROXY = process.env.npm_config_no_proxy;
+
+if (NPM_HTTPS_PROXY) {
+    process.env.HTTPS_PROXY = NPM_HTTPS_PROXY;
+}
+if (NPM_HTTP_PROXY) {
+    process.env.HTTP_PROXY = NPM_HTTP_PROXY;
+}
+if (NPM_NO_PROXY) {
+    process.env.NO_PROXY = NPM_NO_PROXY;
+}
+
+let logged = false;
+
+function onSuccess(localRevisions) {
+    console.log(`Chromium downloaded to ${revisionInfo.folderPath}`);
+    const filteredRevisions = localRevisions.filter(rev => rev !== revisionInfo.revision);
+    // Remove previous chromium revisions.
+    const cleanupOldVersions = filteredRevisions.map(rev => browserFetcher.remove(rev));
+    return Promise.all([...cleanupOldVersions]);
+}
+
+function onProgress() {
+    if (logged) {
+        return;
+    }
+    console.log(`Downloading Chromium r${revision}`);
+    logged = true;
+}
+
+function onError(e) {
+    console.error(`ERROR: Failed to download Chromium r${revision}!`);
+    console.error(e);
+    process.exit(1);
+}
+
+browserFetcher.download(revisionInfo.revision, onProgress)
+    .then(() => browserFetcher.localRevisions())
+    .then(onSuccess)
+    .catch(onError);

--- a/lib/puppeteer/index.js
+++ b/lib/puppeteer/index.js
@@ -1,8 +1,13 @@
 /* eslint-disable global-require */
-const puppeteer = require('puppeteer');
+const Puppeteer = require('puppeteer-core/lib/Puppeteer');
+const packageJson = require('puppeteer-core/package.json');
 const ServeRunner = require('../serve/index');
 const { EventEmitter } = require('events');
 const { parse } = require('flatted/cjs');
+const chromiumCachePath = require('./cache');
+
+const preferredRevision = packageJson.puppeteer.chromium_revision;
+const puppeteer = new Puppeteer(chromiumCachePath, preferredRevision, true);
 
 const DEFAULTS = {
     headless: true,

--- a/lib/serve/named-resolution-middleware.js
+++ b/lib/serve/named-resolution-middleware.js
@@ -1,6 +1,6 @@
 const url = require('url');
 const path = require('path');
-const resolve = require('@kano/es6-resolution');
+const { resolveNamedPath } = require('@kano/es6-resolution');
 const { StringDecoder } = require('string_decoder');
 const mime = require('mime');
 const textChunk = require('node-text-chunk');
@@ -42,7 +42,14 @@ module.exports = (opts = {}) => {
         }
 
         function transformAndSend() {
-            upgradedBody = resolve(root, buffer, contentType, filePath, reqUrl.path, onModule);
+            upgradedBody = resolveNamedPath(
+                root,
+                buffer,
+                contentType,
+                filePath,
+                reqUrl.path,
+                onModule,
+            );
             queue = textChunk.text(upgradedBody, 1024);
             res.setHeader('Content-Length', Buffer.byteLength(upgradedBody, 'utf-8'));
             if (status) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kano/web-tester",
-  "version": "1.0.0-alpha.16",
+  "version": "1.0.0-alpha.17",
   "main": "index.js",
   "license": "MIT",
   "bin": {
@@ -13,10 +13,11 @@
     "web-tester": "node ./bin/cli.js",
     "prepublishOnly": "yarn checkstyle",
     "checkstyle": "eslint ./bin ./lib ./browser.js",
-    "checkstyle-ci": "yarn checkstyle -f checkstyle -o eslint.xml"
+    "checkstyle-ci": "yarn checkstyle -f checkstyle -o eslint.xml",
+    "postinstall": "node ./lib/puppeteer/download.js"
   },
   "dependencies": {
-    "@kano/es6-resolution": "^1.0.8",
+    "@kano/es6-resolution": "^1.0.18",
     "chai": "^4.2.0",
     "chalk": "^2.4.2",
     "connect": "^3.6.6",
@@ -30,7 +31,7 @@
     "mime": "^2.3.1",
     "mocha": "^5.2.0",
     "node-text-chunk": "^0.1.1",
-    "puppeteer": "^1.7.0",
+    "puppeteer-core": "^1.13.0",
     "resolve": "^1.8.1",
     "serve-static": "^1.13.2",
     "sywac": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kano/web-tester",
-  "version": "1.0.0-alpha.15",
+  "version": "1.0.0-alpha.16",
   "main": "index.js",
   "license": "MIT",
   "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,10 +90,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@kano/es6-resolution@^1.0.8":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@kano/es6-resolution/-/es6-resolution-1.0.10.tgz#c8b687cafa2598c9c89a27655392e386fdec76c8"
-  integrity sha512-JC3YcrJ3YNpCq4xH1uf0APANYCfZvficBSEc1gM1S5Iw7Qi7cU0QOpL5hCNBJCp9G/Mb47zDZjPud9EeCLQlmQ==
+"@kano/es6-resolution@^1.0.18":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@kano/es6-resolution/-/es6-resolution-1.0.18.tgz#5060e7ae55be635db5f1c69440dd857b27b45427"
+  integrity sha512-DEHPkeSnofp9nbxNsQpIghmWivNi0s3xxpqDz9a0Zu+2OZDe/gQwXLykJSJc6XMzTGtzm5fy/wISgRxzL1AMpQ==
   dependencies:
     resolve "^1.7.1"
 
@@ -1526,6 +1526,11 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
   integrity sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=
 
+progress@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 proxy-from-env@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
@@ -1536,19 +1541,19 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-puppeteer@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.8.0.tgz#9e8bbd2f5448cc19cac220efc0512837104877ad"
-  integrity sha512-wJ7Fxs03l4dy/ZXQACUKBBobIuJaS4NHq44q7/QinpAXFMwJMJFEIPjzoksVzUhZxQe+RXnjXH69mg13yMh0BA==
+puppeteer-core@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-1.13.0.tgz#f8001851e924e6e9ef6e9fae1778c3ab87c3f307"
+  integrity sha512-8MypjWVHu2EEdtN2HxhCsTtIYdJgiCcbGpHoosv265fzanfOICC2/DadLZq6/Qc/OKsovQmjkO+2vKMrV3BRfA==
   dependencies:
-    debug "^3.1.0"
+    debug "^4.1.0"
     extract-zip "^1.6.6"
     https-proxy-agent "^2.2.1"
     mime "^2.0.3"
-    progress "^2.0.0"
+    progress "^2.0.1"
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
-    ws "^5.1.1"
+    ws "^6.1.0"
 
 range-parser@~1.2.0:
   version "1.2.0"
@@ -1971,10 +1976,10 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^5.1.1:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
-  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+ws@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.0.tgz#13806d9913b2a5f3cbb9ba47b563c002cbc7c526"
+  integrity sha512-deZYUNlt2O4buFCa3t5bKLf8A7FPP/TVjwOeVNpw818Ma5nk4MLXls2eoEGS39o8119QIYxTrTDoPQ5B/gTD6w==
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
 - Use puppeteer-core instead of puppeteer to avoid the automatic download
 - Use BrowserFetcher to download the required version of chromium into a user data directory
 - Re-use the user data directory for every test